### PR TITLE
Ensure sampled length gets passed to the boltz_hallucination call.

### DIFF
--- a/boltzdesign/boltzdesign_utils.py
+++ b/boltzdesign/boltzdesign_utils.py
@@ -1131,6 +1131,7 @@ def run_boltz_design(
                 for itr in range(design_samples):
                     config['length'] = random.randint(config['length_min'],config['length_max'])
                     loss_scales['helix_loss'] = random.uniform(config['helix_loss_min'], config['helix_loss_max'])
+                    filtered_config['length'] = config['length']
 
                     print('pre-run warm up')
                     input_res_type, plots, loss_history, distogram_history, sequence_history, traj_coords_list, traj_plddt_list = boltz_hallucination(


### PR DESCRIPTION
Hi Yehlin,

Cool project. I had an issue generating a binder from the command line interface where despite passing the arguments `--length_min 140` and `--length_max 150` the binder had a length of 100. 

I took a look at the code and I believe the `filtered_config` dictionary just needs to be updated with the sampled length which is only currently being stored in `config`. 

This one-line fix seems to fix the issue in my testing 😄